### PR TITLE
fix(regexp): Use js compatible regexp instead of positive lookbehind

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ for example:
 hyperdocs react
 ```
 
-If the documentation is found, it will open it right away. If it's not, it will open a [duckduckgo](https://duckduckgo.com/) search instead.
+If the documentation is found, it will open it right away. If it's not, it will open a [duckduckgo](https://duckduckgo.com/) search instead (currently broken due to duckduckgo not allowing to be shown in an iframe anymore [#14](https://github.com/uesteibar/hyperdocs/issues/14)).
 
 ## Running locally
 

--- a/src/index.js
+++ b/src/index.js
@@ -51,8 +51,10 @@ exports.middleware = store =>
             data
           )
         ) {
-          const command = /(?<=hyperdocs).*/.exec(data)[0].split(']')[0].trim()
-          store.dispatch({ type: types.TOGGLE, command })
+          const match = /hyperdocs ([^"]*)zsh/.exec(data)
+          if (match) {
+            store.dispatch({ type: types.TOGGLE, command: match[1].trim() })
+          }
         } else {
           next(action)
         }


### PR DESCRIPTION
It seems positive lookbehind is not supported in javascript, so we need to use capturing parenthesis

Fixes #11 

@michaelwayman if you could have a look at this and check it works fine for you, that would be awesome ❤️ 

## Instructions

Go to your hyper plugins folder
```bash
cd ~/.hyper_plugins/local
```

Clone the repository
```bash
git clone --depth=1 git@github.com:uesteibar/hyperdocs.git
```

Install dependencies
```bash
cd hyperdocs
npm install
```

Add to your `.hyper.js` file
```js
localPlugins: ['hyperdocs']
```

And refresh your terminal.